### PR TITLE
Podfile cleanup

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 workspace 'BlueShiftDemoiOSApp.xcworkspace'
 
+# TODO: Set BSFT_IOS_SDK_PATH in your ~/.bashrc or ~/.bash_profile before 'pod install'
+# export BSFT_IOS_SDK_PATH=$HOME/Blueshift/Blueshift-iOS-SDK
+$bsftLocalPath = ENV['BSFT_IOS_SDK_PATH']
+$bsftVersion = '~> 2.0.1'
+$bsftGitURL = 'https://github.com/blueshift-labs/Blueshift-iOS-SDK'
+
 target 'BlueShiftDemoiOSApp' do
   pod 'SVProgressHUD'
   pod 'JSONModel'
@@ -12,33 +18,23 @@ target 'BlueShiftDemoiOSApp' do
   pod 'SDWebImage'
   pod 'IQKeyboardManager'
   pod 'MJPopupViewController'
-  #pod 'BlueShift-iOS-SDK', :path=> '/Users/noufal/Desktop/Projects/Ios/BlueShift/Blueshift-iOS-SDK'
-  #pod 'BlueShift-iOS-SDK', :path=> '/Users/Prometheus/Desktop/BlueShift/Blueshift-iOS-SDK'
-  #pod 'BlueShift-iOS-SDK', :path=> '/Users/Prometheus/Desktop/Blueshift-iOS-SDK'
-  #pod 'BlueShift-iOS-SDK', :git=> 'https://github.com/blueshift-labs/Blueshift-iOS-SDK.git', :branch=> 'alert_view_deprecated'
-  #pod 'BlueShift-iOS-SDK', '~> 1.0.2-beta1'
-  pod 'BlueShift-iOS-SDK'
-  #pod 'BlueShift-iOS-SDK', :git => 'https://github.com/blueshift-labs/Blueshift-iOS-SDK', :branch => 'real_event_with_queue'
   pod 'Firebase/Analytics'
+#  pod 'BlueShift-iOS-SDK', :path => $bsftLocalPath
+#  pod 'BlueShift-iOS-SDK', :git => $bsftGitURL
+#  pod 'BlueShift-iOS-SDK', $bsftVersion
+  pod 'BlueShift-iOS-SDK'
 end
 
 target 'BlueShiftPushService' do
-  #pod 'BlueShift-iOS-Extension-SDK', :path=> '/Users/noufal/Desktop/Projects/Ios/BlueShift/Blueshift-iOS-SDK'
-  #pod 'BlueShift-iOS-Extension-SDK', :path=> '/Users/Prometheus/Desktop/BlueShift/Blueshift-iOS-SDK'
-    #pod 'BlueShift-iOS-Extension-SDK', :path=> '/Users/Prometheus/Desktop/Blueshift-iOS-SDK'
-    #pod 'BlueShift-iOS-SDK/AppExtension', :path=> '/Users/Prometheus/Desktop/BlueShift/Blueshift-iOS-SDK'
-    #pod 'BlueShift-iOS-SDK/AppExtension', :git=> 'https://github.com/blueshift-labs/Blueshift-iOS-SDK.git'
-    #pod 'BlueShift-iOS-SDK/AppExtension'
-    pod 'BlueShift-iOS-Extension-SDK'
+#  pod 'BlueShift-iOS-Extension-SDK', :path => $bsftLocalPath
+#  pod 'BlueShift-iOS-Extension-SDK', :git => $bsftGitURL
+#  pod 'BlueShift-iOS-Extension-SDK', $bsftVersion
+  pod 'BlueShift-iOS-Extension-SDK'
 end
 
 target 'BlueShiftPushContent' do
-  #pod 'BlueShift-iOS-Extension-SDK', :path=> '/Users/noufal/Desktop/Projects/Ios/BlueShift/Blueshift-iOS-SDK'
-  #pod 'BlueShift-iOS-Extension-SDK', :path=> '/Users/Prometheus/Desktop/BlueShift/Blueshift-iOS-SDK'
-    #pod 'BlueShift-iOS-Extension-SDK', :path=> '/Users/Prometheus/Desktop/Blueshift-iOS-SDK'
-    #pod 'BlueShift-iOS-SDK/AppExtension', :path=> '/Users/Prometheus/Desktop/BlueShift/Blueshift-iOS-SDK'
-    #pod 'BlueShift-iOS-SDK/AppExtension', :git=> 'https://github.com/blueshift-labs/Blueshift-iOS-SDK.git'
-    #pod 'BlueShift-iOS-SDK/AppExtension'
-    pod 'BlueShift-iOS-Extension-SDK'
-
+#  pod 'BlueShift-iOS-Extension-SDK', :path => $bsftLocalPath
+#  pod 'BlueShift-iOS-Extension-SDK', :git => $bsftGitURL
+#  pod 'BlueShift-iOS-Extension-SDK', $bsftVersion
+  pod 'BlueShift-iOS-Extension-SDK'
 end


### PR DESCRIPTION
Cleaned up the Podfile to have a fewer number of edits to get started when you clone the sample app.
It also prevents exposing the local directory path in public repo by making use of environmental variables.